### PR TITLE
Story #36: Deploy microservice with service and ingress

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: promotions
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: promotions
+                port:
+                  number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: promotions
+spec:
+  selector:
+    app: promotions
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
What this PR does

This PR completes Story #36 by deploying the Flask promotions microservice to a local K3S Kubernetes cluster. It includes:

- `deployment.yaml` to run the app pod
- `service.yaml` to expose the app within the cluster
- `ingress.yaml` to expose the app on localhost:8080

How to test

1. `make cluster`
2. `make build && make push`
3. `make deploy`
4. `curl localhost:8080/health` → returns `{"status": "OK"}`

Closes #36